### PR TITLE
Issue #11

### DIFF
--- a/app/Usecase/Post/DeleteUsecase.php
+++ b/app/Usecase/Post/DeleteUsecase.php
@@ -5,6 +5,9 @@ namespace App\Usecase\Post;
 
 use App\Http\Payload;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
 
 
 class DeleteUsecase
@@ -12,11 +15,17 @@ class DeleteUsecase
     public function destroy($post)
     {
         try {
+            DB::beginTransaction();
             if(Auth::id() == $post->user_id){
                 $post->delete();
             }
+            DB::commit();
+
             return (new Payload())->setStatus(Payload::SUCCESS);
         } catch (\Exception $e) {
+            Log::error($e);
+            DB::rollBack();
+
             return (new Payload())->setStatus(Payload::FAILED);
         }
     }

--- a/app/Usecase/Post/DeleteUsecase.php
+++ b/app/Usecase/Post/DeleteUsecase.php
@@ -21,12 +21,12 @@ class DeleteUsecase
             }
             DB::commit();
 
-            return (new Payload())->setStatus(Payload::SUCCESS);
         } catch (\Exception $e) {
             Log::error($e);
             DB::rollBack();
 
             return (new Payload())->setStatus(Payload::FAILED);
         }
+        return (new Payload())->setStatus(Payload::SUCCESS);
     }
 }

--- a/app/Usecase/Post/StoreUsecase.php
+++ b/app/Usecase/Post/StoreUsecase.php
@@ -5,15 +5,23 @@ namespace App\Usecase\Post;
 
 
 use App\Http\Payload;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class StoreUsecase
 {
     public function store($request)
     {
         try {
+            DB::beginTransaction();
             $request->user()->posts()->create($request->only('body'));
+            DB::commit();
+
             return (new Payload())->setStatus(Payload::SUCCESS);
         } catch (\Exception $e) {
+            Log::error($e);
+            DB::rollBack();
+
             return (new Payload())->setStatus(Payload::FAILED);
         }
     }

--- a/app/Usecase/Post/StoreUsecase.php
+++ b/app/Usecase/Post/StoreUsecase.php
@@ -17,12 +17,12 @@ class StoreUsecase
             $request->user()->posts()->create($request->only('body'));
             DB::commit();
 
-            return (new Payload())->setStatus(Payload::SUCCESS);
         } catch (\Exception $e) {
             Log::error($e);
             DB::rollBack();
 
             return (new Payload())->setStatus(Payload::FAILED);
         }
+            return (new Payload())->setStatus(Payload::SUCCESS);
     }
 }

--- a/app/Usecase/PostLike/DestroyUsecase.php
+++ b/app/Usecase/PostLike/DestroyUsecase.php
@@ -17,12 +17,12 @@ class DestroyUsecase
             $request->user()->likes()->where('post_id', $post->id)->delete();
             DB::commit();
 
-            return (new Payload())->setStatus(Payload::DELETED);
         } catch (\Exception $e) {
             Log::error($e);
             DB::rollBack();
 
             return (new Payload())->setStatus(Payload::FAILED);
         }
+            return (new Payload())->setStatus(Payload::DELETED);
     }
 }

--- a/app/Usecase/PostLike/DestroyUsecase.php
+++ b/app/Usecase/PostLike/DestroyUsecase.php
@@ -5,15 +5,23 @@ namespace App\Usecase\PostLike;
 
 
 use App\Http\Payload;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class DestroyUsecase
 {
     public function destroy($post, $request)
     {
         try {
+            DB::beginTransaction();
             $request->user()->likes()->where('post_id', $post->id)->delete();
+            DB::commit();
+
             return (new Payload())->setStatus(Payload::DELETED);
         } catch (\Exception $e) {
+            Log::error($e);
+            DB::rollBack();
+
             return (new Payload())->setStatus(Payload::FAILED);
         }
     }

--- a/app/Usecase/PostLike/StoreUsecase.php
+++ b/app/Usecase/PostLike/StoreUsecase.php
@@ -8,21 +8,29 @@ use App\Http\Payload;
 use App\Models\Post;
 use App\Mail\PostLiked;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class StoreUsecase
 {
     public function store(Post $post, Request $request)
     {
         try {
-//            if user already liked some post, then show only "unlike" button
+            DB::beginTransaction();
+            // if user already liked some post, then show only "unlike" button
             if ($post->likedBy($request->user())) {
                 return (new Payload())->setStatus(Payload::UPDATED);
             }
             $post->likes()->create([
                 'user_id' => $request->user()->id,
             ]);
+            DB::commit();
+
             return (new Payload())->setStatus(Payload::CREATED);
         } catch (\Exception $e) {
+            Log::error($e);
+            DB::rollBack();
+
             return (new Payload())->setStatus(Payload::FAILED);
         }
     }

--- a/app/Usecase/PostLike/StoreUsecase.php
+++ b/app/Usecase/PostLike/StoreUsecase.php
@@ -26,12 +26,12 @@ class StoreUsecase
             ]);
             DB::commit();
 
-            return (new Payload())->setStatus(Payload::CREATED);
         } catch (\Exception $e) {
             Log::error($e);
             DB::rollBack();
 
             return (new Payload())->setStatus(Payload::FAILED);
         }
+            return (new Payload())->setStatus(Payload::CREATED);
     }
 }

--- a/app/Usecase/Register/RegisterUsecase.php
+++ b/app/Usecase/Register/RegisterUsecase.php
@@ -5,7 +5,9 @@ namespace App\Usecase\Register;
 use App\Command\User\CreateCommand;
 use App\Http\Payload;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
 
 
 class RegisterUsecase
@@ -13,6 +15,7 @@ class RegisterUsecase
     public function run(CreateCommand $command)
     {
         try {
+            DB::beginTransaction();
             User::create([
                 'username' => $command->getUsername(),
                 'name' => $command->getName(),
@@ -24,7 +27,11 @@ class RegisterUsecase
                 'email' => $command->getEmail(),
                 'password' => $command->getPassword(),
             ]);
+            DB::commit();
+
         } catch(\Exception $e) {
+            Log::error($e);
+            DB::rollBack();
             return (new Payload())->setStatus(Payload::FAILED);
         }
 

--- a/app/Usecase/Register/RegisterUsecase.php
+++ b/app/Usecase/Register/RegisterUsecase.php
@@ -32,9 +32,9 @@ class RegisterUsecase
         } catch(\Exception $e) {
             Log::error($e);
             DB::rollBack();
+
             return (new Payload())->setStatus(Payload::FAILED);
         }
-
         return (new Payload())->setStatus(Payload::CREATED);
     }
 }


### PR DESCRIPTION
## 変更の目的
**Issue #11 に対応するため**

■修正内容
DBへのCRUD操作のうち、CUDの操作については必ず、トランザクションやtry-catchを使用してください。

## 変更の概要
 - DBへのCUD操作を行う際にトランザクションを使用し、
 失敗時には①処理の破棄（`DB::rollBack()`） / ②ログへの書き込み（`Log::error($e)`）を行うよう修正
 - 成功時ステータスコード（`Payload::SUCCESS`）のリターン場所の変更
→挙動が想定通り（エラーが発生していない状態）であることを確認済み。