### PR TITLE
Like処理の例外処理を修正

### DIFF
--- a/app/Usecase/PostLike/StoreUsecase.php
+++ b/app/Usecase/PostLike/StoreUsecase.php
@@ -16,11 +16,12 @@ class StoreUsecase
     public function store(Post $post, Request $request)
     {
         try {
-            DB::beginTransaction();
             // if user already liked some post, then show only "unlike" button
             if ($post->likedBy($request->user())) {
-                return (new Payload())->setStatus(Payload::UPDATED);
+                return (new Payload())->setStatus(Payload::FAILED);
             }
+
+            DB::beginTransaction();
             $post->likes()->create([
                 'user_id' => $request->user()->id,
             ]);


### PR DESCRIPTION
## 変更の概要
Like処理の例外処理を変更しました

変更前：想定外の処理（ログインユーザーが既にLikeをしているのにも関わらずLikeできてしまう状況）を更新（成功と同等）のステータスで返してしまっていた。
変更後：上記事象を失敗処理として扱い、例外処理を行う。